### PR TITLE
Fix suggestion selection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,14 +22,14 @@ IMPORTANT: NEVER WRITE COMMENTS UNLESS ASKED. Code should be self descriptive. I
 Just fix issues. Don't write comments explaining the problem or solution.
 
 Example of good:
-[no comment at all]
+Code that describes itself without the need for comments.
 
 Example of good approved comment:
 // sentence one. Sentence two.
 
 ## State management style
 
-Remember: you might not need an effect. useEffect and similar is generally a lazy approach. Don't be lazy. Avoid useEffect by doing one or more of the following:
+Remember: you might not need an effect. useEffect and similar effect-based triggers are generally a lazy approach. Don't be lazy. Avoid using effects by doing one or more of the following:
 
 1. Trigger stateful changes through events
 2. Pass state in as props to a component

--- a/components/learn/postContent/keyhole.tsx
+++ b/components/learn/postContent/keyhole.tsx
@@ -25,7 +25,7 @@ export default function Keyhole() {
       <Story storyParagraphs={[`There is a long road. Peaku has been walking all day in a light rain. He has just left the familiar behind. The path is rough and muddy, and that is to say nothing of the bugs.`, `The path turns steep. He slips through rocks and mud. He is in pain, and although he can stand easily, he does not.`, `A green bird lands on his mud-covered chest. A jewel in the rough. It screams out a mocking laugh.`,`What do you want, bird, Peaku says.`,`Watch you suffer! the bird says.`,`"What?"`,`The bird mocks him and flies off a short ways. It looks back at Peaku. Peaku stands and follows, weary of traps or evil creatures.`, `No such dangers appear. The bird perches on a dry log under a small rocky overhang. It hops, flutters the wet off its wings. Snack! it squawks.`, `Peaku drops his pack and sits down heavily. He offers the bird some nuts from his palm. It is a messy eater and finishes them off quickly.`,`Progress! Progress! it says.`, `Progress, Peaku agrees. 🦜`]}/>
       <p>{`Often, it can be hard to know when you're solving an F2L pair perfectly. When you get to use keyhole, you'll pretty much know you're making progress. Any other way you could solve it will almost always be worse.`}</p>
       <h1>When to use keyhole</h1>
-      <p>{`You can use keyhole whenever these three things are all true:`}</p>
+      <p>{`You can use keyhole whenever these things are true:`}</p>
       <LessonList items={["There is an F2L pair where one piece is solved and the other piece is in the top layer, and", "There is another slot that isn't solved"]}/>
       <p>{`A "slot" is the location where a corner and edge piece need to get solved in the first and second layer. There's usually four unsolved slots after you solve cross.`}</p>
       <p>{`Let's look at those keyhole examples again.`}</p>
@@ -65,7 +65,8 @@ export default function Keyhole() {
         </div>
       </div>
       <p>{`It's called keyhole because, well, it's like we're inserting a key into a hole. Imagine that.`}</p>
-      <p>{`One exception to be aware of. If the corner has the cross color facing up, keyhole doesn't really make the pair that much more efficient. You'd probably be better off solving something else.`}</p>
+      <p>{`I oversimplified earlier. Opinions differ on when to use keyhole. Solving corner cases with keyhole is typically not much better than solving with pure `}<code>RU</code> or <code>LU</code>{` moves. It's up to you to figure out which you prefer in the long term, but keyhole is perfectly okay to start off.`}</p>
+      <p>{`Additionally, if the cross color on the corner is facing up, using keyhole won't make the case much better. You'd probably be better off solving something else.`}</p>
       <h2>The edge case</h2>
       <p>{`Now we'll say the corner is the piece that's in the way. We need to move that corner out of the way, but this will put a different corner in the slot we're trying to solve the edge into. As long as we don't care about that corner, we're fine.`}</p>
       <p>{`The back right slot is unsolved here. Let's use that. We'll do`}<code>{`D'`}</code>{` to move its corner into the slot we care about. We'll also do`}<code>{`U`}</code>{` at the same time to set up for inserting the edge.`}</p>
@@ -77,6 +78,7 @@ export default function Keyhole() {
       <h1>{`That's it`}</h1>
       <p>{`You now know keyhole! Not much to this one, really. But that doesn't mean it won't take some getting used to. Do untimed solves so that you can get used to spotting these cases.`}</p>
       <p>{`The slot you're trying to solve doesn't have to be in the front. That was just easier to show in a tutorial. You could solve cases where all the relevant pieces are in the back, if you can manage to spot them.`}</p>
+      <p>{`Before you click play, try to spot the keyhole case.`}</p>
       <div className="flex flex-col gap-1 pb-4">
         <div className="w-80 h-80.5 border border-neutral-400 rounded-sm overflow-hidden">
           <iframe src="/learn/keyhole/hard.html" className="w-165 h-165 overflow-hidden scale-50 origin-top-left" />

--- a/components/recon/MovesTextEditor.tsx
+++ b/components/recon/MovesTextEditor.tsx
@@ -1112,7 +1112,7 @@ function MovesTextEditor({
     });
   };
 
-  const handleSuggestionReject = () => {
+  const dismissSuggestion = () => {
     if (name === 'scramble') return;
     // the preview is an overlay, so dismissing is pure state — no HTML surgery.
     suggestionManagerRef.current?.dismissSuggestion();
@@ -1130,7 +1130,8 @@ function MovesTextEditor({
 
       e.preventDefault();
       if (canAcceptSuggestion) {
-        handleSuggestionAccept();
+        const acceptText = manager?.getAcceptText();
+        if (acceptText) insertAcceptedSuggestion(acceptText);
         return;
       }
       // re-show after the user previously dismissed with Esc
@@ -1138,7 +1139,7 @@ function MovesTextEditor({
     }
 
     if (e.key === 'Escape' && !e.shiftKey && !e.ctrlKey && !e.altKey && !e.metaKey) {
-      handleSuggestionReject();
+      dismissSuggestion();
     }
 
     const isMac =
@@ -1215,14 +1216,11 @@ function MovesTextEditor({
   };
 
   /**
-   * Handle tab key confirmation of any suggested text.
+   * Insert confirmed suggestion text, from either the Tab key or a tap on a card.
    */
-  const handleSuggestionAccept = () => {
+  const insertAcceptedSuggestion = (remaining: string) => {
     if (!contentEditableRef.current) return;
     if (name === 'scramble') return; // no suggestions in scramble
-
-    const remaining = suggestionManagerRef.current?.getAcceptText();
-    if (!remaining) return;
 
     const targetLineIndex = lineOffsetRef.current;
 
@@ -1743,8 +1741,8 @@ function MovesTextEditor({
         topOffset={suggestionTopOffset}
         leftOffset={suggestionLeftOffset}
         showTabHint={supportsHardwareKeyboard}
-        onAcceptSuggestion={handleSuggestionAccept}
-        onRejectSuggestion={handleSuggestionReject}
+        onAccept={insertAcceptedSuggestion}
+        onReject={dismissSuggestion}
       />
     </div>
   );

--- a/components/recon/SuggestionBox.tsx
+++ b/components/recon/SuggestionBox.tsx
@@ -14,36 +14,36 @@ interface SuggestionBoxProps {
   selectedOriginalIndex: number | null;
   topOffset: number;
   leftOffset: number;
-  handleSuggestionRequest: (index: number) => void;
-  handleSuggestionAccept: () => void;
-  handleSuggestionReject: () => void;
+  onSelect: (originalIndex: number) => void;
+  onAccept: (originalIndex: number) => void;
+  onReject: () => void;
 }
 
-export const SuggestionBox = ({suggestions, selectedOriginalIndex, topOffset, leftOffset, handleSuggestionRequest, handleSuggestionAccept, handleSuggestionReject }: SuggestionBoxProps) => {
+export const SuggestionBox = ({suggestions, selectedOriginalIndex, topOffset, leftOffset, onSelect, onAccept, onReject }: SuggestionBoxProps) => {
   const foundIndex = suggestions.findIndex((item) => item.originalIndex === selectedOriginalIndex);
   const selectedIndex = foundIndex === -1 ? 0 : foundIndex;
 
-  const navigationStateRef = useRef({ suggestions, selectedIndex, handleSuggestionRequest });
-  navigationStateRef.current = { suggestions, selectedIndex, handleSuggestionRequest };
+  const navigationStateRef = useRef({ suggestions, selectedIndex, onSelect });
+  navigationStateRef.current = { suggestions, selectedIndex, onSelect };
 
-  const focusHoveredElement = (index: number) => {
+  const selectAtIndex = (index: number) => {
     if (!suggestions[index]) return;
-    handleSuggestionRequest(suggestions[index].originalIndex);
+    onSelect(suggestions[index].originalIndex);
   }
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       // tab event handled by parent component
-      const { suggestions: current, selectedIndex: currentIndex, handleSuggestionRequest: request } = navigationStateRef.current;
+      const { suggestions: current, selectedIndex: currentIndex, onSelect: select } = navigationStateRef.current;
       if (!current.length) return;
 
       if (event.key === 'ArrowDown') {
         event.preventDefault();
-        request(current[(currentIndex + 1) % current.length].originalIndex);
+        select(current[(currentIndex + 1) % current.length].originalIndex);
       }
       if (event.key === 'ArrowUp') {
         event.preventDefault();
-        request(current[(currentIndex - 1 + current.length) % current.length].originalIndex);
+        select(current[(currentIndex - 1 + current.length) % current.length].originalIndex);
       }
     };
 
@@ -85,8 +85,8 @@ export const SuggestionBox = ({suggestions, selectedOriginalIndex, topOffset, le
             steps={item.suggestion.steps}
             hasEOsolved={item.suggestion.hasEOsolved}
             algset={item.suggestion.algset}
-            handleSuggestionRequest={() => focusHoveredElement(index)}
-            handleSuggestionAccept={handleSuggestionAccept}
+            onSelect={() => selectAtIndex(index)}
+            onAccept={() => onAccept(item.originalIndex)}
           />
         )
       })
@@ -98,7 +98,7 @@ export const SuggestionBox = ({suggestions, selectedOriginalIndex, topOffset, le
         flex flex-row items-center gap-3 w-fit border-t-dark
         border rounded-b-sm border-neutral-400 bg-primary-300 text-dark text-md p-1
         ${isTouchScreen ? 'min-w-25 justify-center' : 'w-fit'}`}
-        onClick={handleSuggestionReject}>
+        onClick={onReject}>
           Cancel
         { !isTouchScreen ? (
         <img src="/esc.svg" alt="Esc" className='mb-0.5 border border-dark'/>

--- a/components/recon/SuggestionCard.tsx
+++ b/components/recon/SuggestionCard.tsx
@@ -14,8 +14,8 @@ interface SuggestionCardProps {
   isFocused: boolean;
   hasEOsolved?: boolean;
   algset?: Algset;
-  handleSuggestionRequest: () => void;
-  handleSuggestionAccept: () => void;
+  onSelect: () => void;
+  onAccept: () => void;
 }
 
 const extractF2LColors = (step: string, letterToColor: Record<string, string>): string[] => {
@@ -97,7 +97,7 @@ const renderStepIcon = (steps: string[], letterToColor: Record<string, string>, 
   return renderTextIcon(steps[0] || '?');
 };
 
-export const SuggestionCard = ({ alg, steps, id, placement, isFocused, hasEOsolved, algset, handleSuggestionRequest, handleSuggestionAccept }: SuggestionCardProps) => {
+export const SuggestionCard = ({ alg, steps, id, placement, isFocused, hasEOsolved, algset, onSelect, onAccept }: SuggestionCardProps) => {
   const { settings } = useSyncedSettings();
   const { cubeColors } = settings;
 
@@ -157,9 +157,9 @@ export const SuggestionCard = ({ alg, steps, id, placement, isFocused, hasEOsolv
         ${placement === 'only' ? 'rounded-t-sm rounded-br-sm' : ''}
         `
       }
-      onMouseOver={handleSuggestionRequest}
+      onMouseOver={onSelect}
       onMouseDown={(event) => event.preventDefault()}
-      onClick={handleSuggestionAccept}
+      onClick={onAccept}
       id={id}
       tabIndex={0}
     >

--- a/components/recon/SuggestionManager.tsx
+++ b/components/recon/SuggestionManager.tsx
@@ -54,8 +54,8 @@ interface SuggestionManagerProps {
   topOffset: number;
   leftOffset: number;
   showTabHint: boolean;
-  onAcceptSuggestion: () => void;
-  onRejectSuggestion: () => void;
+  onAccept: (acceptText: string) => void;
+  onReject: () => void;
   ref?: Ref<SuggestionManagerHandle>;
 }
 
@@ -126,8 +126,8 @@ export function SuggestionManager({
   topOffset,
   leftOffset,
   showTabHint,
-  onAcceptSuggestion,
-  onRejectSuggestion,
+  onAccept,
+  onReject,
   ref,
 }: SuggestionManagerProps) {
   const [{ suggestions, lineIndex: suggestionLineIndex }, setSuggestionState] = useState<SuggestionState>({
@@ -206,6 +206,16 @@ export function SuggestionManager({
     },
   }));
 
+  const acceptByOriginalIndex = (originalIndex: number) => {
+    const item = filteredSuggestions?.find((entry) => entry.originalIndex === originalIndex);
+    if (!item) return;
+
+    const acceptText = resolveRemaining(item.suggestion.alg, getLineText(activeLineHtml));
+    if (!acceptText) return;
+
+    onAccept(acceptText);
+  };
+
   if (!shouldShow || !filteredSuggestions) {
     return null;
   }
@@ -218,9 +228,9 @@ export function SuggestionManager({
           selectedOriginalIndex={selectedItem?.originalIndex ?? null}
           topOffset={topOffset}
           leftOffset={leftOffset}
-          handleSuggestionRequest={(index) => setSelectedOriginalIndex(index)}
-          handleSuggestionAccept={onAcceptSuggestion}
-          handleSuggestionReject={onRejectSuggestion}
+          onSelect={(index) => setSelectedOriginalIndex(index)}
+          onAccept={acceptByOriginalIndex}
+          onReject={onReject}
         />,
         overlayElement,
       )}

--- a/todo.txt
+++ b/todo.txt
@@ -14,6 +14,9 @@ A completely intuitive f2l guide
 
 Add roux algs
 Missing L' U' L2 U L2' U' L and mirrors, y2?
+L' U' L R' U2 R2 U R'
+why y' U R U' R2' U2' R U2 R' U R and not y' R U' R2' U2' R U2 R' U R?
+Free both pieces + Make pair = Free pair
 
 Think about function of solve review carefully. Form will follow.
 - Add breakdown into MovesTextEditor? Explore adding divs.
@@ -27,6 +30,13 @@ Roux icons in YourAlgsList
 Wack suggestion
 http://localhost:3000/algs/?a=f2l&c=y3022000000000000
 
+https://www.ao1k.com/algs/?a=f2l&p=WBO&c=y231001110
+Breakdown for U2 r' F' r R' D R U' R' D' R is bad, same for inverse above. F U' R U' R' U2 F' should be higher. 
+Can we explain F<R,U>F, better? Like F, pair, F'?
+Set up testing. We should set up a way to input algs and output breakdowns, then get a list of breakdowns that are correct.
+
+Canonicalization breaks unneeded AUF removal. Suggestion keeps AUF in original canonicalized form even when not needed. 
+
 Create custom OG previews of different F2L cases on the Algs page:
 - Description: How to solve this case
 - Logo:
@@ -34,3 +44,5 @@ Create custom OG previews of different F2L cases on the Algs page:
   - Top 3 solutions, or however many fit.
   - "Click link for more info"
 - Add a share button above Solutions
+
+Pasting in text should not trigger most text substitutions, only LW -> l and X/Y/Z -> x/y/z. Not NN -> N2, NM -> N M, or UD -> (U D).


### PR DESCRIPTION
Fix a suggestion selection bug on mobile, edit keyhole lesson. On mobile, no hover event meant that the `remaining` text wasn't getting updated ever. This bypasses that by using originalIndex values instead. Renamed some functions as well..